### PR TITLE
Track archived support rooms

### DIFF
--- a/apps/chat_server/lib/chat_server/contexts/rooms/track_support_rooms.ex
+++ b/apps/chat_server/lib/chat_server/contexts/rooms/track_support_rooms.ex
@@ -22,7 +22,9 @@ defmodule ChatServer.TrackSupportRooms do
     case Map.get(list(), key(room)) do
       nil ->
         Presence.track(pid, @presence_key, key(room), %{
-          slug: room.slug
+          slug: room.slug,
+          type: room.type,
+          state: room.state
         })
       _data ->
         Logger.warn "Support room already tracked #{room.slug}" <> inspect(pid)


### PR DESCRIPTION
These changes are needed in order to keep the archived/active state synced for support room tracking. This will make it easier for clients to display room states without needing custom behaviors to check support room state and room subscription